### PR TITLE
Add dashboard mockup

### DIFF
--- a/ui/public/dashboard.css
+++ b/ui/public/dashboard.css
@@ -1,0 +1,397 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    min-height: 100vh;
+    color: #333;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.header {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 30px;
+    margin-bottom: 30px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    position: relative;
+}
+
+.header h1 {
+    font-size: 2.5rem;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 10px;
+}
+
+.header p {
+    color: #666;
+    font-size: 1.1rem;
+}
+
+.connection-status {
+    position: absolute;
+    right: 60px;
+    top: 35px;
+    font-size: 0.9rem;
+}
+
+.theme-toggle {
+    position: absolute;
+    right: 20px;
+    top: 30px;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 30px;
+    margin-bottom: 30px;
+}
+
+.card {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 25px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
+}
+
+.card h3 {
+    color: #333;
+    margin-bottom: 15px;
+    font-size: 1.3rem;
+}
+
+.main-content {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 30px;
+}
+
+.task-board {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 30px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.board,
+.board-columns {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.column {
+    background: #f8f9fa;
+    border-radius: 15px;
+    padding: 20px;
+    min-height: 400px;
+}
+
+.column h4 {
+    color: #495057;
+    margin-bottom: 15px;
+    font-size: 1.1rem;
+    text-align: center;
+    padding: 10px;
+    background: white;
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.task-card {
+    background: white;
+    border-radius: 10px;
+    padding: 15px;
+    margin-bottom: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    border-left: 4px solid;
+    cursor: grab;
+    transition: transform 0.2s ease;
+}
+
+.task-card:hover {
+    transform: scale(1.02);
+}
+
+.task-card.priority-high {
+    border-left-color: #e74c3c;
+}
+
+.task-card.priority-medium {
+    border-left-color: #f39c12;
+}
+
+.task-card.priority-low {
+    border-left-color: #27ae60;
+}
+
+.task-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: #2c3e50;
+}
+
+.task-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.85rem;
+    color: #7f8c8d;
+}
+
+.agent-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 0.7rem;
+    font-weight: bold;
+}
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+}
+
+.stat-card {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    padding: 20px;
+    border-radius: 15px;
+    text-align: center;
+}
+
+.stat-number {
+    font-size: 2rem;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.stat-label {
+    font-size: 0.9rem;
+    opacity: 0.9;
+}
+
+.btn {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: white;
+    border: none;
+    padding: 12px 24px;
+    border-radius: 10px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: transform 0.2s ease;
+    margin: 5px;
+}
+
+.btn:hover {
+    transform: translateY(-2px);
+}
+
+.btn-secondary {
+    background: #6c757d;
+}
+
+.team-member {
+    display: flex;
+    align-items: center;
+    padding: 12px;
+    border-radius: 10px;
+    background: #f8f9fa;
+    margin-bottom: 10px;
+}
+
+.member-status {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-left: auto;
+}
+
+.status-active {
+    background: #28a745;
+}
+
+.status-busy {
+    background: #ffc107;
+}
+
+.status-offline {
+    background: #6c757d;
+}
+
+.progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #e9ecef;
+    border-radius: 4px;
+    overflow: hidden;
+    margin: 10px 0;
+}
+
+.progress-fill {
+    height: 100%;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    transition: width 0.3s ease;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(5px);
+    z-index: 1000;
+}
+
+.modal-content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: white;
+    border-radius: 20px;
+    padding: 30px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
+    color: #495057;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+    width: 100%;
+    padding: 12px;
+    border: 2px solid #e9ecef;
+    border-radius: 10px;
+    font-size: 1rem;
+    transition: border-color 0.3s ease;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.close-btn {
+    position: absolute;
+    top: 15px;
+    right: 20px;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: #6c757d;
+}
+
+.ai-agents {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border-radius: 20px;
+    padding: 25px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.agent-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+    margin-top: 15px;
+}
+
+.agent-card {
+    background: #f8f9fa;
+    border-radius: 15px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.agent-card:hover {
+    transform: translateY(-3px);
+}
+
+.agent-icon {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin: 0 auto 10px;
+}
+
+@media (max-width: 768px) {
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+    .main-content {
+        grid-template-columns: 1fr;
+    }
+    .board,
+    .board-columns {
+        grid-template-columns: 1fr;
+    }
+    .stats-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/ui/public/dashboard.html
+++ b/ui/public/dashboard.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Dev Team Dashboard</title>
+    <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🚀 AI Development Command Center</h1>
+            <p>Orchestrate your AI software development team with precision and insight</p>
+            <span id="connection-status" class="connection-status">Connecting...</span>
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">🌙</button>
+        </div>
+
+        <div class="dashboard-grid">
+            <div class="card">
+                <h3>📋 Active Sprint</h3>
+                <div class="progress-bar">
+                    <div class="progress-fill" style="width: 68%"></div>
+                </div>
+                <p>Sprint 3.2 - 68% Complete</p>
+                <p style="color: #666; font-size: 0.9rem;">5 days remaining</p>
+            </div>
+            <div class="card">
+                <h3>🎯 Project Health</h3>
+                <div style="display: flex; align-items: center; gap: 10px;">
+                    <div style="width: 40px; height: 40px; border-radius: 50%; background: #28a745; display: flex; align-items: center; justify-content: center; color: white; font-weight: bold;">A+</div>
+                    <div>
+                        <p style="font-weight: 600;">Excellent</p>
+                        <p style="color: #666; font-size: 0.9rem;">On track for delivery</p>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <h3>⚡ Team Velocity</h3>
+                <div style="font-size: 2rem; font-weight: bold; color: #667eea;">42</div>
+                <p style="color: #666;">Story points this sprint</p>
+                <p style="color: #28a745; font-size: 0.9rem;">↗ +15% from last sprint</p>
+            </div>
+        </div>
+
+        <div class="main-content">
+            <div class="task-board">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+                    <h2>📊 Development Pipeline</h2>
+                    <div>
+                        <a href="#" id="create-task-link" class="btn">+ New Task</a>
+                    </div>
+                </div>
+                <div class="filter">
+                    <input id="task-filter" type="text" placeholder="Search tasks...">
+                    <select id="agent-filter"><option value="">All agents</option></select>
+                    <select id="epic-filter"><option value="">All epics</option></select>
+                    <select id="priority-filter">
+                        <option value="">All priorities</option>
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                    </select>
+                    <button id="save-filter" type="button">Save Filter</button>
+                    <select id="saved-filters"><option value="">Saved filters</option></select>
+                    <div class="quick-filters">
+                        <button data-priority="high" type="button">High</button>
+                        <button data-priority="medium" type="button">Medium</button>
+                        <button data-priority="low" type="button">Low</button>
+                    </div>
+                </div>
+                <div class="board board-columns">
+                    <div class="column" data-status="pending">
+                        <h4>📝 Backlog</h4>
+                    </div>
+                    <div class="column" data-status="in-progress">
+                        <h4>🔄 In Progress</h4>
+                    </div>
+                    <div class="column" data-status="review">
+                        <h4>🔍 Review</h4>
+                    </div>
+                    <div class="column" data-status="done">
+                        <h4>✅ Done</h4>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar">
+                <div class="card">
+                    <h3>📈 Sprint Metrics</h3>
+                    <div class="stats-grid">
+                        <div class="stat-card">
+                            <div class="stat-number">24</div>
+                            <div class="stat-label">Tasks</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-number">89%</div>
+                            <div class="stat-label">Quality</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-number">6</div>
+                            <div class="stat-label">Agents</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-number">3.2</div>
+                            <div class="stat-label">Velocity</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card">
+                    <h3>🤖 AI Team Status</h3>
+                    <div class="team-member">
+                        <div class="agent-avatar">FE</div>
+                        <div style="margin-left: 10px;">
+                            <div style="font-weight: 600;">Frontend Agent</div>
+                            <div style="color: #666; font-size: 0.9rem;">React Components</div>
+                        </div>
+                        <div class="member-status status-active"></div>
+                    </div>
+                    <div class="team-member">
+                        <div class="agent-avatar">BE</div>
+                        <div style="margin-left: 10px;">
+                            <div style="font-weight: 600;">Backend Agent</div>
+                            <div style="color: #666; font-size: 0.9rem;">API Development</div>
+                        </div>
+                        <div class="member-status status-busy"></div>
+                    </div>
+                    <div class="team-member">
+                        <div class="agent-avatar">ML</div>
+                        <div style="margin-left: 10px;">
+                            <div style="font-weight: 600;">ML Agent</div>
+                            <div style="color: #666; font-size: 0.9rem;">Model Training</div>
+                        </div>
+                        <div class="member-status status-active"></div>
+                    </div>
+                    <div class="team-member">
+                        <div class="agent-avatar">QA</div>
+                        <div style="margin-left: 10px;">
+                            <div style="font-weight: 600;">QA Agent</div>
+                            <div style="color: #666; font-size: 0.9rem;">Testing</div>
+                        </div>
+                        <div class="member-status status-offline"></div>
+                    </div>
+                </div>
+                <div class="card">
+                    <h3>⚡ Quick Actions</h3>
+                    <button class="btn" style="width: 100%; margin: 5px 0;" onclick="alert('Generate tasks from PRD')">Generate Tasks from PRD</button>
+                    <button class="btn" style="width: 100%; margin: 5px 0;" onclick="alert('Plan next sprint')">Plan Next Sprint</button>
+                    <button class="btn btn-secondary" style="width: 100%; margin: 5px 0;" onclick="alert('Generate report')">Generate Report</button>
+                </div>
+            </div>
+        </div>
+        <div class="ai-agents" style="margin-top: 30px;">
+            <h3>🤖 AI Development Team</h3>
+            <div class="agent-grid">
+                <div class="agent-card">
+                    <div class="agent-icon">FE</div>
+                    <h4>Frontend Agent</h4>
+                    <p style="color: #666; font-size: 0.9rem;">React, Vue, Angular specialist</p>
+                </div>
+                <div class="agent-card">
+                    <div class="agent-icon">BE</div>
+                    <h4>Backend Agent</h4>
+                    <p style="color: #666; font-size: 0.9rem;">API, Database, Server logic</p>
+                </div>
+                <div class="agent-card">
+                    <div class="agent-icon">ML</div>
+                    <h4>ML Agent</h4>
+                    <p style="color: #666; font-size: 0.9rem;">Machine Learning, AI models</p>
+                </div>
+                <div class="agent-card">
+                    <div class="agent-icon">QA</div>
+                    <h4>QA Agent</h4>
+                    <p style="color: #666; font-size: 0.9rem;">Testing, Quality assurance</p>
+                </div>
+                <div class="agent-card">
+                    <div class="agent-icon">DO</div>
+                    <h4>DevOps Agent</h4>
+                    <p style="color: #666; font-size: 0.9rem;">CI/CD, Infrastructure</p>
+                </div>
+                <div class="agent-card">
+                    <div class="agent-icon">SA</div>
+                    <h4>Solutions Architect</h4>
+                    <p style="color: #666; font-size: 0.9rem;">System design, Architecture</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="task-modal" class="modal hidden">
+        <form id="task-form" class="modal-content">
+            <h3 id="modal-title">Create Task</h3>
+            <label>Title
+                <input type="text" name="title" required>
+            </label>
+            <label>Description
+                <textarea name="description" required></textarea>
+            </label>
+            <label>Agent
+                <select name="agent">
+                    <option value="">Select agent</option>
+                    <option>Agent A</option>
+                    <option>Agent B</option>
+                </select>
+            </label>
+            <label>Epic
+                <select name="epic">
+                    <option value="">Select epic</option>
+                    <option>Frontend</option>
+                    <option>Backend</option>
+                    <option>DevOps</option>
+                </select>
+            </label>
+            <label>Priority
+                <select name="priority">
+                    <option value="low">Low</option>
+                    <option value="medium" selected>Medium</option>
+                    <option value="high">High</option>
+                </select>
+            </label>
+            <label>Status
+                <select name="status">
+                    <option value="pending">Backlog</option>
+                    <option value="in-progress">In Progress</option>
+                    <option value="review">Review</option>
+                    <option value="done">Done</option>
+                </select>
+            </label>
+            <div class="form-actions">
+                <button type="submit">Save</button>
+                <button type="reset" id="task-reset">Reset</button>
+                <button type="button" id="task-cancel">Cancel</button>
+            </div>
+        </form>
+    </div>
+
+    <script>
+    const toggle = document.getElementById('theme-toggle');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const stored = localStorage.getItem('theme');
+    const current = stored || (prefersDark ? 'dark' : 'light');
+    document.body.setAttribute('data-theme', current);
+    toggle.textContent = current === 'dark' ? '☀️' : '🌙';
+    toggle.addEventListener('click', () => {
+        const theme = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        document.body.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        toggle.textContent = theme === 'dark' ? '☀️' : '🌙';
+    });
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dashboard mockup page with sample layout
- include standalone dashboard stylesheet

## Testing
- `npm test` *(fails: saveCurrentFilter not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5907f2c8329b5bf0fd60c791620