### PR TITLE
refactor: centralize server logging

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -85,9 +85,9 @@ app.use('/api/agents', agentsRouter);
 app.use('/api/ai-agents', aiAgentsRouter);
 app.use('/api/team/performance', teamPerformanceRouter);
 // Debug logging for flow optimization route
-console.log('Registering flow optimization routes');
+logger.debug('Registering flow optimization routes');
 app.use('/api/flow-optimization', flowOptimizationRouter);
-console.log('Flow optimization routes registered');
+logger.debug('Flow optimization routes registered');
 
 app.use('/api/mcp', mcpRouter);
 app.use('/api/cli', cliRouter);

--- a/server/routes/flow-optimization.js
+++ b/server/routes/flow-optimization.js
@@ -132,7 +132,7 @@ const mockFlowData = {
 
 // Register explicit route for debugging
 router.get('/', (req, res) => {
-  console.log('Root flow optimization route accessed');
+  logger.debug('Root flow optimization route accessed');
   res.json({ message: 'Flow optimization API is available' });
 });
 
@@ -144,9 +144,9 @@ router.get('/', (req, res) => {
 // TODO: Implement actual API endpoint when real data source is available
 // This is currently just a mock endpoint that returns simulated data
 router.get('/data', (req, res) => {
-  console.log('⭐ Flow optimization /data endpoint requested - NOTE: This is currently a mock endpoint');
+  logger.debug('⭐ Flow optimization /data endpoint requested - NOTE: This is currently a mock endpoint');
   try {
-    console.log('Returning mock flow optimization data');
+    logger.debug('Returning mock flow optimization data');
     logger.info('Returning mock flow optimization data - real implementation pending');
     
     // Simulate some variability in the data
@@ -312,7 +312,7 @@ setInterval(() => {
     mockFlowData.bottlenecks.push(newBottleneck);
     
     // This would broadcast to WebSocket clients
-    console.log('New bottleneck detected:', newBottleneck);
+    logger.debug('New bottleneck detected:', newBottleneck);
   }
 
   // Simulate metric updates

--- a/server/routes/prd.js
+++ b/server/routes/prd.js
@@ -8,6 +8,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import validate from '../middleware/validation.js';
 import { PRDSchema } from '../schemas/prd.js';
+import logger from '../utils/logger.js';
 
 const router = express.Router();
 const execAsync = promisify(exec);
@@ -241,7 +242,7 @@ router.post('/process/:fileId', async (req, res, next) => {
           const tasksContent = fs.readFileSync(tasksFile, 'utf8');
           tasksData = JSON.parse(tasksContent);
         } catch (parseError) {
-          console.warn('Failed to parse tasks.json:', parseError);
+          logger.warn('Failed to parse tasks.json:', parseError);
         }
       }
 
@@ -270,7 +271,7 @@ router.post('/process/:fileId', async (req, res, next) => {
           }
           processingJobs.delete(fileId);
         } catch (cleanupError) {
-          console.warn('Failed to cleanup file:', cleanupError);
+          logger.warn('Failed to cleanup file:', cleanupError);
         }
       }, 300000); // Clean up after 5 minutes
 

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import logger from '../utils/logger.js';
 import { readJSON, writeJSON } from '../../scripts/modules/utils.js';
 import validate from '../middleware/validation.js';
 import { TaskSchema } from '../schemas/task.js';
@@ -25,7 +26,7 @@ const TASKS_FILE =
 	process.env.TASKS_FILE ||
 	path.join(__dirname, '../../.taskmaster/tasks/tasks.json');
 
-console.log(`[DEBUG] TASKS_FILE path: ${TASKS_FILE}`);
+logger.debug(`[DEBUG] TASKS_FILE path: ${TASKS_FILE}`);
 
 function getVersion() {
 	try {
@@ -36,9 +37,9 @@ function getVersion() {
 }
 
 function loadTasks() {
-        console.log(`[DEBUG] Loading tasks from: ${TASKS_FILE}`);
+        logger.debug(`[DEBUG] Loading tasks from: ${TASKS_FILE}`);
         const data = readJSON(TASKS_FILE) || { schemaVersion: 1, tasks: [] };
-        console.log(`[DEBUG] Loaded data:`, data ? `${data.tasks?.length || 0} tasks` : 'null');
+        logger.debug(`[DEBUG] Loaded data:`, data ? `${data.tasks?.length || 0} tasks` : 'null');
         return Array.isArray(data.tasks) ? data.tasks : [];
 }
 
@@ -57,7 +58,7 @@ router.put('/:id/assign', (req, res, next) => {
             return res.status(400).json({ error: 'Task ID and agent ID are required' });
         }
         
-        console.log(`[DEBUG] Assigning agent ${agentId} to task ${id}`);
+        logger.debug(`[DEBUG] Assigning agent ${agentId} to task ${id}`);
         
         // Load tasks and find the target task
         const tasks = loadTasks();
@@ -232,7 +233,7 @@ router.get('/stats', (req, res, next) => {
 router.get('/activities', (req, res, next) => {
     try {
         const tasks = loadTasks();
-        console.log(`[DEBUG] Loaded ${tasks.length} tasks for activities`);
+        logger.debug(`[DEBUG] Loaded ${tasks.length} tasks for activities`);
         let activities = [];
         
         // Generate real activities from actual task data and timestamps
@@ -322,7 +323,7 @@ router.get('/activities', (req, res, next) => {
             }
         });
         
-        console.log(`[DEBUG] Generated ${activities.length} real activities from task data`);
+        logger.debug(`[DEBUG] Generated ${activities.length} real activities from task data`);
         
         // Sort by date descending (most recent first)
         activities.sort((a, b) => new Date(b.date) - new Date(a.date));
@@ -333,10 +334,10 @@ router.get('/activities', (req, res, next) => {
             .filter(activity => new Date(activity.date) >= thirtyDaysAgo)
             .slice(0, 15);
         
-        console.log(`[DEBUG] Returning ${activities.length} recent activities (last 30 days)`);
+        logger.debug(`[DEBUG] Returning ${activities.length} recent activities (last 30 days)`);
         res.json(activities);
     } catch (err) {
-        console.log(`[DEBUG] Error in activities endpoint:`, err);
+        logger.debug(`[DEBUG] Error in activities endpoint:`, err);
         next(err);
     }
 });
@@ -516,8 +517,8 @@ router.get('/statistics/daily', (req, res, next) => {
             }
         });
 
-        console.log(`[DEBUG] Generated daily statistics from ${tasks.length} tasks across ${dailyStats.length} days`);
-        console.log(`[DEBUG] Daily stats summary:`, dailyStats.map(s => `${s.date}: ${s.total} total (${s.completed}c, ${s.inProgress}i, ${s.pending}p)`));
+        logger.debug(`[DEBUG] Generated daily statistics from ${tasks.length} tasks across ${dailyStats.length} days`);
+        logger.debug(`[DEBUG] Daily stats summary:`, dailyStats.map(s => `${s.date}: ${s.total} total (${s.completed}c, ${s.inProgress}i, ${s.pending}p)`));
 
         res.json({
             dateRange: {
@@ -559,7 +560,7 @@ router.get('/statistics/current', (req, res, next) => {
             total: total
         }];
         
-        console.log(`[DEBUG] Current task breakdown: ${completed} completed, ${inProgress} in-progress, ${pending} pending, ${blocked} blocked, ${deferred} deferred (${total} total)`);
+        logger.debug(`[DEBUG] Current task breakdown: ${completed} completed, ${inProgress} in-progress, ${pending} pending, ${blocked} blocked, ${deferred} deferred (${total} total)`);
         
         res.json({
             dateRange: {

--- a/server/utils/activityLogger.js
+++ b/server/utils/activityLogger.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import logger from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -76,7 +77,7 @@ function writeActivityEntry(activityEntry) {
     const logLine = JSON.stringify(activityEntry) + '\n';
     fs.appendFileSync(ACTIVITY_LOG_PATH, logLine, 'utf8');
     
-    console.log(`[ACTIVITY] ${activityEntry.activityType}: ${activityEntry.details.taskId || activityEntry.details.id || 'N/A'}`);
+    logger.info(`[ACTIVITY] ${activityEntry.activityType}: ${activityEntry.details.taskId || activityEntry.details.id || 'N/A'}`);
   } catch (error) {
     console.error('Failed to write activity log:', error);
   }


### PR DESCRIPTION
## Summary
- replace all console.log/warn calls in server modules
- use logger.debug/info/warn for consistent logging

## Testing
- `npm run format-check` *(fails: biome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cb6fb27c83298812608b338f1575